### PR TITLE
Add fix for a Microsoft Edge (and more?) error present nested elements

### DIFF
--- a/dist/docrel.js
+++ b/dist/docrel.js
@@ -27,8 +27,7 @@ function createElement(tag) {
 
   var result = document.createElement(tag);
 
-  result.textContent = options.textContent;
-
+  if (options.textContent) result.textContent = options.textContent;
   if (options.innerHTML) result.innerHTML = options.innerHTML;
   if (options.id) result.id = options.id;
   if (options.class) result.className = options.class;
@@ -107,6 +106,7 @@ var meta = exports.meta = create("meta")[0];
 var nav = exports.nav = create("nav")[0];
 var ol = exports.ol = create("ol")[0];
 var option = exports.option = create("option")[0];
+var p = exports.p = create("p")[0];
 var progress = exports.progress = create("progress")[0];
 var script = exports.script = create("script")[0];
 var section = exports.section = create("section")[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docrel",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Slightly better document.createElement",
   "main": "dist/docrel.js",
   "scripts": {

--- a/src/docrel.js
+++ b/src/docrel.js
@@ -7,8 +7,7 @@ export function create(...tags) {
 export function createElement(tag, options = {}, children) {
   let result = document.createElement(tag)
 
-  result.textContent = options.textContent
-
+  if (options.textContent) result.textContent = options.textContent
   if (options.innerHTML) result.innerHTML = options.innerHTML
   if (options.id) result.id = options.id
   if (options.class) result.className = options.class
@@ -75,6 +74,7 @@ export let meta = create("meta")[0]
 export let nav = create("nav")[0]
 export let ol = create("ol")[0]
 export let option = create("option")[0]
+export let p = create("p")[0]
 export let progress = create("progress")[0]
 export let script = create("script")[0]
 export let section = create("section")[0]


### PR DESCRIPTION
So it turns out that Microsoft Edge (and possibly other flavours of I.E) likes to throw 'Undefined' all over the place when using nested elements in docrel.

<img width="1027" alt="untitled" src="https://user-images.githubusercontent.com/1840398/33558576-1a0e4dac-d902-11e7-8cd2-b14b07960e05.png">

This is because of this line of code:

```
result.textContent = options.textContent
```

MEdge seems to like to evaluate `options.textContent` as undefined but then strinigyfing it and placing it in the element. Not sure if this is more standards-true or whether it's just a bug. Either way, checking for truthy first solves the problem.

I've also added the `<p>` element alias.